### PR TITLE
Build libtiff with JPEG support

### DIFF
--- a/com.github.unrud.djpdf.yaml
+++ b/com.github.unrud.djpdf.yaml
@@ -891,6 +891,17 @@ modules:
 
   - shared-modules/openjpeg/openjpeg.json
 
+  # libtiff with JPEG support
+  # https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1117
+  - name: libtiff
+    buildsystem: cmake-ninja
+    cleanup:
+       - '*.so'
+    sources:
+       - type: git
+         url: https://gitlab.com/libtiff/libtiff.git
+         tag: v4.2.0
+
   - name: imagemagick
     sources:
       - type: archive


### PR DESCRIPTION
The runtime doesn't have libtiff build with JPEG support.

See:
https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/issues/1117

Without this, files generated by ScanTailor using JPEG compression (see bug https://github.com/flathub/com.github._4lex4.ScanTailor-Advanced/pull/1 for the counterpart) aren't open, and ScanToPDF hangs.