### PR TITLE
Rebuild: KDE runtime Qt ABI breakage

### DIFF
--- a/com.github.unrud.djpdf.yaml
+++ b/com.github.unrud.djpdf.yaml
@@ -380,6 +380,8 @@ modules:
         done
     cleanup:
       - /bin
+      - /PySide6/include
+      - /shiboken6/include
     sources:
       - type: archive
         url: https://download.qt.io/official_releases/QtForPython/pyside6/PySide6-6.10.3-src/pyside-setup-everywhere-src-6.10.3.tar.xz


### PR DESCRIPTION
```
ImportError: /app/lib/python3.13/site-packages/PySide6/QtCore.abi3.so: undefined symbol: _ZN14QObjectPrivateC2E16QtPrivate_6_10_2, version Qt_6_PRIVATE_API
```